### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 description = "A terminal-ui (TUI) client for the Miniflux RSS reader"
 readme = "README.md"
-homepage = "https://github.com/spencerwi/cliflux"
+repository = "https://github.com/spencerwi/cliflux"
 license = "MIT"
 keywords = [
 	"tui", "terminal_ui", "miniflux", "rss", "cli"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).