### PR TITLE
Add support for `use_rustls` config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1272,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1267,6 +1282,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1275,12 +1291,28 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1303,12 +1335,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1337,6 +1391,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1734,6 +1798,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,6 +1971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2115,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ directories = "4.0.1"
 futures = "0.3.26"
 html2text = { version = "0.5.0", features = ["ansi_colours"] }
 open = "3.2.0"
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest = { version = "0.11.24", features = ["json", "rustls-tls"] }
 serde = { version = "1.0.152", features = ["std", "derive"] }
 serde_json = "1.0.93"
 stringreader = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ That TOML file should look like this:
 server_url = "your-miniflux-server-url-here-including-port"
 api_key = "your-miniflux-api-key-here"
 allow_invalid_certs = false
+use_rustls = false
 ```
 
 You can stub out a default config file by running `cliflux --init`, which will also tell you where the config file 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct Config {
     pub server_url: String,
     #[serde(default)]
     pub allow_invalid_certs: bool,
+    #[serde(default)]
+    pub use_rustls: bool,
 	#[serde(default)]
 	pub theme : ThemeConfig,
 }
@@ -78,6 +80,7 @@ impl Default for Config {
             api_key: "FIXME".to_string(),
             server_url: "FIXME".to_string(),
             allow_invalid_certs: false,
+            use_rustls: false,
 			theme: ThemeConfig::default()
         }
     }

--- a/src/libminiflux.rs
+++ b/src/libminiflux.rs
@@ -78,13 +78,20 @@ impl Client {
         let api_key = &config.api_key;
         let base_url = config.server_url.clone();
         let invalid_certs = config.allow_invalid_certs;
+        let use_rustls = config.use_rustls;
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
             HeaderName::from_bytes(b"X-Auth-Token").unwrap(),
             HeaderValue::from_str(&api_key).unwrap(),
         );
-        let http_client = reqwest::Client::builder()
+
+        let mut builder = reqwest::Client::builder();
+        if use_rustls {
+            builder = builder.use_rustls_tls();
+        }
+
+        let http_client = builder
             .danger_accept_invalid_certs(invalid_certs)
             .default_headers(default_headers)
             .build()


### PR DESCRIPTION
Add new configuration option `use_rustls` to enable support for TLS 1.3 on host where `native-tls` does not support it

> The `native-tls` does not work on macOs 15.6 when connecting to
> servers where minimum TLS version is set to TLS 1.3